### PR TITLE
/predict Endpoint Testing

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -30,4 +30,5 @@ def configure_routes(app):
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)
-        return jsonify(np.asscalar(prediction))
+
+        return jsonify(np.ndarray.item(prediction))

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -33,7 +33,9 @@ def test_predict_route():
         })
 
         assert response.status_code == 200
-
+        assert int(response.data.strip()) >= 0
+        assert int(response.data.strip()) <= 20 
+        
         # Testing missing args
         
         response = client.get(url, query_string={

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -45,7 +45,7 @@ def test_predict_route():
 
         assert response.status_code == 400
 
-        # Testing non-existed args
+        # Testing additional args
         response = client.get(url, query_string={
             "age": 19,
             "health": 1,
@@ -59,6 +59,14 @@ def test_predict_route():
         response = client.get(url, query_string={
             "age": 'NaN',
             "health": 1,
+            "absences": 17,
+        })
+
+        assert response.status_code == 400
+
+        # Testing special characters
+        response = client.get(url, query_string={
+            "age": '1&health=2',
             "absences": 17,
         })
 

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -2,14 +2,8 @@ from flask import Flask
 
 from app.handlers.routes import configure_routes
 
-# import logging
-
-
-
 app = Flask(__name__)
 configure_routes(app)
-
-
 
 def test_base_route():
     with app.test_client() as client:
@@ -29,9 +23,13 @@ def test_predict_route():
         # testing valid args
 
         response = client.get(url, query_string={
-            "age": 19,
-            "health": 1,
-            "absences": 17,
+            "studytime": 1,
+            "failures": 1,
+            "absences": 20,
+            "activities": True,
+            "internet": True,
+            "medu": 3,
+            "fedu": 3,
         })
 
         assert response.status_code == 200
@@ -39,17 +37,24 @@ def test_predict_route():
         # Testing missing args
         
         response = client.get(url, query_string={
-            "age": 19,
-            "health": 1,
+            "studytime": 1,
+            "failures": 1,
+            "absences": 20,
+            "activities": True,
+            "internet": True,
         })
 
         assert response.status_code == 400
 
         # Testing additional args
         response = client.get(url, query_string={
-            "age": 19,
-            "health": 1,
-            "absences": 17,
+            "studytime": 1,
+            "failures": 1,
+            "absences": 20,
+            "activities": True,
+            "internet": True,
+            "medu": 3,
+            "fedu": 3,
             "grade": 17,
         })
 
@@ -57,23 +62,32 @@ def test_predict_route():
 
         # Testing invalid arg type
         response = client.get(url, query_string={
-            "age": 'NaN',
-            "health": 1,
-            "absences": 17,
+            "studytime": "NaN",
+            "failures": 1,
+            "absences": 20,
+            "activities": True,
+            "internet": True,
+            "medu": 3,
+            "fedu": 3,
         })
 
         assert response.status_code == 400
 
         # Testing special characters
         response = client.get(url, query_string={
-            "age": '1&health=2',
-            "absences": 17,
+            "studytime": '1&failures=1',
+            "failures": 1,
+            "absences": 20,
+            "activities": True,
+            "internet": True,
+            "medu": 3,
+            "fedu": 3,
         })
 
         assert response.status_code == 400
 
         # Testing malformed request body
-        response = client.get(url, query_string=[19, 1, 17])
+        response = client.get(url, query_string=[1, 1, 20, True, True, 3, 3])
 
         assert response.status_code == 400
 
@@ -83,5 +97,3 @@ def test_invalid_address():
         response = client.get('/change')
 
         assert response.status_code == 404
-
-

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -2,14 +2,78 @@ from flask import Flask
 
 from app.handlers.routes import configure_routes
 
+# import logging
+
+
+
+app = Flask(__name__)
+configure_routes(app)
+
+
 
 def test_base_route():
-    app = Flask(__name__)
-    configure_routes(app)
-    client = app.test_client()
-    url = '/'
+    with app.test_client() as client:
 
-    response = client.get(url)
+        url = '/'
 
-    assert response.status_code == 200
-    assert response.get_data() == b'try the predict route it is great!'
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.get_data() == b'try the predict route it is great!'
+
+def test_predict_route():
+    with app.test_client() as client:
+
+        url = '/predict'
+
+        # testing valid args
+
+        response = client.get(url, query_string={
+            "age": 19,
+            "health": 1,
+            "absences": 17,
+        })
+
+        assert response.status_code == 200
+
+        # Testing missing args
+        
+        response = client.get(url, query_string={
+            "age": 19,
+            "health": 1,
+        })
+
+        assert response.status_code == 400
+
+        # Testing non-existed args
+        response = client.get(url, query_string={
+            "age": 19,
+            "health": 1,
+            "absences": 17,
+            "grade": 17,
+        })
+
+        assert response.status_code == 200
+
+        # Testing invalid arg type
+        response = client.get(url, query_string={
+            "age": 'NaN',
+            "health": 1,
+            "absences": 17,
+        })
+
+        assert response.status_code == 400
+
+        # Testing malformed request body
+        response = client.get(url, query_string=[19, 1, 17])
+
+        assert response.status_code == 400
+
+def test_invalid_address():
+    with app.test_client() as client:
+        # Testing invalid address
+        response = client.get('/change')
+
+        assert response.status_code == 404
+
+


### PR DESCRIPTION
Added test cases for the `/predict` endpoint.

Tested for:
- Valid arguments, should get a 200 response
- Valid arguments, response should lie in the valid range [0, 20]
- Invalid argument types, should throw 400 Bad Request
- Missing arguments, should throw 400 Bad Request
- Additional arguments, should pass 200